### PR TITLE
Fixed bug where output would be blank

### DIFF
--- a/demovir.sh
+++ b/demovir.sh
@@ -8,7 +8,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 prodigal -a AA.fasta -i $1 -p meta &> /dev/null
 echo "Genes predicted"
-usearch -ublast AA.fasta -db $DIR/uniprot_trembl.viral.udb -evalue 1e-5 -blast6out trembl_ublast.viral.txt -threads $2 &> /dev/null
+usearch -ublast AA.fasta -db $DIR/uniprot_trembl.viral.udb -evalue 1e-5 -trunclabels -blast6out trembl_ublast.viral.txt -threads $2 &> /dev/null
 echo "UBLAST complete"
 sort -u -k1,1 trembl_ublast.viral.txt > trembl_ublast.viral.u.txt
 rm AA.fasta 


### PR DESCRIPTION
Adding -trunclabels to usearch parameters restores proper naming of each protein query and allows for successful analysis by the R script. 
Without -trunclabels additional "sequence labels" information is includes in the name of each query "myProtein1 # 4530 # 5276 # 1 # ID=502_8;partial=00;start_type=ATG;rbs_motif=TAA;rbs_spacer=7bp;gc_cont=0.471" when it should just be "myProtein1".